### PR TITLE
kernel v0.2.1

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,48 @@
+# SafaOS Features
+This is an attempt to make a roadmap and a list of current features.
+
+If you want a more detailed overview of the current api features checkout the [safa-api docs](https://docs.rs/safa-api/latest/safa_api/).
+
+## Program Ports
+Some cool and useful programs that were ported to `SafaOS`:
+- [X] [lua](https://github.com/ObserverUnit/SafaOS-lua/tree/v5.4)
+- [ ] Doom
+
+## Library Ports
+Some useful libraries that were ported to `SafaOS`:
+- [X] Rust's [libstd](https://github.com/SafaOS/rust/tree/stable)
+- [X] [libc](https://github.com/SafaOS/libc)
+
+## Userspace & Tasks
+Overview of what processes can currently do:
+- [X] ring3
+- [X] ELF-loader
+- [X] Single Threaded Basic Scheduler
+- [X] Environment variables
+- [X] Arguments
+- [ ] IPC
+- [ ] Signals
+- [ ] Threads
+
+# VFS
+Overview of what the VFS can currently do & ported file systems:
+- [X] Creating & opening
+- [ ] Deleting & renaming & moving
+- [X] Operations: reading, writing, truncating, ioctl, buffering (sync), iterating directories
+- [X] TmpFS
+- [X] unix-like proc FS `proc:/`
+- [X] unix-like devices FS `dev:/` (TmpFS under the hood)
+
+# Devices & Drivers
+- [X] PS2 Keyboard Driver
+- [X] Serial Device: `dev:/ss`
+- [X] TTY Emulator: `dev:/tty` (to be removed)
+- [ ] Framebuffer Device: `dev:/fb`
+
+# Architectures
+- [X] x86_64
+- [ ] Arm64 (tracking issue: #24)
+
+# Bootloaders
+- [X] UEFI Limine
+- [ ] BIOS Limine

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 An open-source non-Unix-like OS, written from scratch in Rust for fun.
 
 ## Building
-you need: 
+you need:
 
 - bash
 - git
@@ -52,14 +52,14 @@ you can also use the `run.sh` script to debug:
 and then connect to port 1234 with a gdb client i recommend using `rust-lldb`.
 
 ### Additional Information
-avalable arguments for the `run.sh` script are:
+available arguments for the `run.sh` script are:
 
 - `no-kvm`: disables kvm
 - `no-gui`: disables gui
 - `debugger`: listens on port 1234 for a debugger
 
 ## Testing
-there is an automated testing script called `test.sh` which is used to test SafaOS automatcally
+there is an automated testing script called `test.sh` which is used to test SafaOS automatically
 you'll need:
 
 - qemu-system-x86_64
@@ -70,9 +70,11 @@ you'll need:
 the script will return a non-zero exit code if any testing fails
 
 ## Current Features
-there is a bunch of userspace programs written in rust in the `binutils/` directory they are compiled and then copied to the ramdisk as `sys:/bin/`, you can check them out alongside the `tests` for almost everything the kernel is currently capable of.
+Check `FEATURES.md`.
 
-> aside from the rust stdandard library another method to interact with the kernel is through the [safa-api](https://github.com/SafaOS/safa-api) which provides low-level wrapper functions around the syscalls, and also some high-level wrappers (such as a userspace allocator which is a very high-level wrapper around the sbrk syscall, ofc the raw sbrk syscall is still exposed), the problem is it is currently not documented.
+There is also a bunch of userspace programs written in rust in the `binutils/` directory they are compiled and then copied to the ramdisk as `sys:/bin/`, you can check them out alongside the `tests` for almost everything the kernel is currently capable of.
+
+> Aside from the rust stdandard library another method to interact with the kernel is through the [safa-api](https://github.com/SafaOS/safa-api) which provides low-level wrapper functions around the syscalls, and also some high-level wrappers (such as a userspace allocator which is a very high-level wrapper around the sbrk syscall, ofc the raw sbrk syscall is still exposed).
 
 ## Credits
 currently uses the [limine](https://limine-bootloader.org/) bootloader.

--- a/abi/Cargo.lock
+++ b/abi/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",

--- a/abi/Cargo.lock
+++ b/abi/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",

--- a/abi/Cargo.lock
+++ b/abi/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",

--- a/abi/Cargo.lock
+++ b/abi/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",

--- a/abi/Cargo.lock
+++ b/abi/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",

--- a/abi/Cargo.lock
+++ b/abi/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "safa-abi"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",

--- a/abi/Cargo.lock
+++ b/abi/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safa-abi"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 description = "an ABI over some of the SafaOS's structures kernel"
 repository = "https://github.com/SafaOS/SafaOS"

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safa-abi"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "an ABI over some of the SafaOS's structures kernel"
 repository = "https://github.com/SafaOS/SafaOS"

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -21,3 +21,8 @@ rustc-dep-of-std = ["core", "alloc", "compiler_builtins/rustc-dep-of-std"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(target_os, values("safaos"))']
+
+[package.metadata.docs.rs]
+
+default-target = "x86_64-unknown-none"
+targets = []

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safa-abi"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "an ABI over some of the SafaOS's structures kernel"
 repository = "https://github.com/SafaOS/SafaOS"

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safa-abi"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "an ABI over some of the SafaOS's structures kernel"
 repository = "https://github.com/SafaOS/SafaOS"

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safa-abi"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 description = "an ABI over some of the SafaOS's structures kernel"
 repository = "https://github.com/SafaOS/SafaOS"

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safa-abi"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "an ABI over some of the SafaOS's structures kernel"
 repository = "https://github.com/SafaOS/SafaOS"

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safa-abi"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "an ABI over some of the SafaOS's structures kernel"
 repository = "https://github.com/SafaOS/SafaOS"

--- a/abi/src/errors.rs
+++ b/abi/src/errors.rs
@@ -2,26 +2,27 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
 pub enum ErrorStatus {
-    // use when no ErrorStatus is avalible for xyz and you cannot add a new one
+    /// use when no ErrorStatus is available for xyz and you cannot add a new one
     Generic = 1,
     OperationNotSupported = 2,
-    // for example an elf class is not supported, there is a difference between NotSupported and
-    // OperationNotSupported
+    /// for example an elf class is not supported, there is a difference between NotSupported and
+    /// OperationNotSupported
     NotSupported = 3,
-    // for example a magic value is invaild
+    /// for example a magic value is invalid
     Corrupted = 4,
-    InvaildSyscall = 5,
-    InvaildResource = 6,
-    InvaildPid = 7,
-    InvaildOffset = 8,
-    // instead of panicking syscalls will return this on null and unaligned pointers
-    InvaildPtr = 9,
-    // for operations that requires a vaild utf8 str...
-    InvaildStr = 0xA,
-    // for operations that requires a str that doesn't exceed a max length such as
-    // file names (128 bytes)
+    InvalidSyscall = 5,
+    InvalidResource = 6,
+    InvalidPid = 7,
+    InvalidOffset = 8,
+    /// instead of panicking syscalls will return this on null and unaligned pointers
+    /// some operations may accept null pointers
+    InvalidPtr = 9,
+    /// for operations that requires a valid utf8 str...
+    InvalidStr = 0xA,
+    /// for operations that requires a str that doesn't exceed a max length such as
+    /// file names (128 bytes)
     StrTooLong = 0xB,
-    InvaildPath = 0xC,
+    InvalidPath = 0xC,
     NoSuchAFileOrDirectory = 0xD,
     NotAFile = 0xE,
     NotADirectory = 0xF,
@@ -29,7 +30,7 @@ pub enum ErrorStatus {
     NotExecutable = 0x11,
     // would be useful when i add remove related operations to the vfs
     DirectoryNotEmpty = 0x12,
-    // Generic premissions(protection) related error
+    // Generic permissions(protection) related error
     MissingPermissions = 0x13,
     // memory allocations and mapping error, most likely that memory is full
     MMapError = 0x14,
@@ -52,14 +53,14 @@ impl ErrorStatus {
             OperationNotSupported => "Operation Not Supported",
             NotSupported => "Object Not Supported",
             Corrupted => "Corrupted",
-            InvaildSyscall => "Invaild Syscall",
-            InvaildResource => "Invaild Resource",
-            InvaildPid => "Invaild PID",
-            InvaildOffset => "Invaild Offset",
-            InvaildPtr => "Invaild Ptr (not aligned or null)",
-            InvaildStr => "Invaild Str (not utf8)",
+            InvalidSyscall => "Invalid Syscall",
+            InvalidResource => "Invalid Resource",
+            InvalidPid => "Invalid PID",
+            InvalidOffset => "Invalid Offset",
+            InvalidPtr => "Invalid Ptr (not aligned or null)",
+            InvalidStr => "Invalid Str (not utf8)",
             StrTooLong => "Str too Long",
-            InvaildPath => "Invaild Path",
+            InvalidPath => "Invalid Path",
             NoSuchAFileOrDirectory => "No Such a File or Directory",
             NotAFile => "Not a File",
             NotADirectory => "Not a Directory",

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -4,7 +4,7 @@
 compile_error!("abi should only be used for SafaOS or freestanding targets");
 
 pub mod errors;
-pub mod io;
+pub mod raw;
 pub mod syscalls;
 
 pub mod consts {

--- a/abi/src/raw/io.rs
+++ b/abi/src/raw/io.rs
@@ -1,3 +1,5 @@
+use crate::consts;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum InodeType {
@@ -22,5 +24,5 @@ pub struct FileAttr {
 pub struct DirEntry {
     pub attrs: FileAttr,
     pub name_length: usize,
-    pub name: [u8; super::consts::MAX_NAME_LENGTH],
+    pub name: [u8; consts::MAX_NAME_LENGTH],
 }

--- a/abi/src/raw/mod.rs
+++ b/abi/src/raw/mod.rs
@@ -5,6 +5,7 @@ use core::ptr::NonNull;
 
 #[repr(C)]
 #[derive(Debug)]
+/// A C complitable slice of type `T`
 pub struct RawSlice<T> {
     ptr: *const T,
     len: usize,
@@ -77,6 +78,7 @@ impl<T> RawSliceMut<RawSlice<T>> {
 
 #[repr(C)]
 #[derive(Debug)]
+/// A C complitable mutable slice of type `T`
 pub struct RawSliceMut<T> {
     ptr: *mut T,
     len: usize,

--- a/abi/src/raw/mod.rs
+++ b/abi/src/raw/mod.rs
@@ -90,7 +90,7 @@ impl<T> RawSliceMut<T> {
 impl<T> RawSliceMut<RawSlice<T>> {
     /// Converts a slice of slices of [`T`] into [`RawSliceMut<RawSlice<T>>`]
     /// # Safety
-    /// `slices` becomes invaild after use
+    /// `slices` becomes invalid after use
     /// as it is going to be reused as a memory location for creating `Self`
     /// making this unexpensive but dangerous
     /// O(N) expect if the Layout of RawSlice is equal to the Layout of rust slices, and it has been optimized it is O(1)
@@ -153,6 +153,12 @@ impl<T> NonNullSlice<T> {
 pub enum Optional<T> {
     None,
     Some(T),
+}
+
+impl<T> Default for Optional<T> {
+    fn default() -> Self {
+        Self::None
+    }
 }
 
 impl<T> From<Option<T>> for Optional<T> {

--- a/abi/src/raw/mod.rs
+++ b/abi/src/raw/mod.rs
@@ -5,7 +5,7 @@ use core::ptr::NonNull;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-/// A C complitable slice of type `T`
+/// A C compatible slice of type `T`
 pub struct RawSlice<T> {
     ptr: *const T,
     len: usize,
@@ -33,6 +33,21 @@ impl<T> RawSlice<T> {
     pub fn as_ptr(&self) -> *const T {
         self.ptr
     }
+
+    /// Converts a [`RawSlice<T>`] into a slice of type `T`
+    ///
+    /// returns `None` if the slice ptr is null or the length is zero
+    /// # Safety
+    ///
+    /// panics if the slice ptr is not aligned to the alignment of `T`
+    #[inline(always)]
+    pub unsafe fn into_slice<'a>(self) -> Option<&'a [T]> {
+        if self.ptr.is_null() || self.len == 0 {
+            None
+        } else {
+            Some(core::slice::from_raw_parts(self.ptr, self.len))
+        }
+    }
 }
 
 impl<T> RawSliceMut<T> {
@@ -54,6 +69,21 @@ impl<T> RawSliceMut<T> {
     #[inline(always)]
     pub fn as_mut_ptr(&self) -> *mut T {
         self.ptr
+    }
+
+    /// Converts a [`RawSliceMut<T>`] into a slice of type `T`
+    ///
+    /// returns `None` if the slice ptr is null or the length is zero
+    /// # Safety
+    ///
+    /// panics if the slice ptr is not aligned to the alignment of `T`
+    #[inline(always)]
+    pub unsafe fn into_slice_mut<'a>(self) -> Option<&'a mut [T]> {
+        if self.ptr.is_null() || self.len == 0 {
+            None
+        } else {
+            Some(core::slice::from_raw_parts_mut(self.ptr, self.len))
+        }
     }
 }
 
@@ -94,6 +124,26 @@ pub struct NonNullSlice<T> {
 impl<T> NonNullSlice<T> {
     pub const unsafe fn from_raw_parts(ptr: NonNull<T>, len: usize) -> Self {
         Self { ptr, len }
+    }
+
+    pub const fn as_non_null(&self) -> NonNull<T> {
+        self.ptr
+    }
+
+    pub const fn as_ptr(&self) -> *mut T {
+        self.ptr.as_ptr()
+    }
+
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Converts a [`NonNullSlice<T>`] into a slice of type `T`
+    /// # Safety
+    /// panics if the slice ptr is not aligned to the alignment of `T`
+    #[inline(always)]
+    pub unsafe fn into_slice_mut<'a>(self) -> &'a mut [T] {
+        unsafe { core::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
     }
 }
 

--- a/abi/src/raw/mod.rs
+++ b/abi/src/raw/mod.rs
@@ -4,7 +4,7 @@ pub mod processes;
 use core::ptr::NonNull;
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 /// A C complitable slice of type `T`
 pub struct RawSlice<T> {
     ptr: *const T,
@@ -77,7 +77,7 @@ impl<T> RawSliceMut<RawSlice<T>> {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 /// A C complitable mutable slice of type `T`
 pub struct RawSliceMut<T> {
     ptr: *mut T,
@@ -85,7 +85,7 @@ pub struct RawSliceMut<T> {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct NonNullSlice<T> {
     ptr: NonNull<T>,
     len: usize,

--- a/abi/src/raw/mod.rs
+++ b/abi/src/raw/mod.rs
@@ -1,0 +1,148 @@
+pub mod io;
+pub mod processes;
+
+use core::ptr::NonNull;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct RawSlice<T> {
+    ptr: *const T,
+    len: usize,
+}
+
+impl<T> RawSlice<T> {
+    #[inline(always)]
+    pub unsafe fn from_raw_parts(ptr: *const T, len: usize) -> Self {
+        Self { ptr, len }
+    }
+    #[inline(always)]
+    pub unsafe fn from_slice(slice: &[T]) -> Self {
+        Self {
+            ptr: slice.as_ptr(),
+            len: slice.len(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline(always)]
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
+}
+
+impl<T> RawSliceMut<T> {
+    #[inline(always)]
+    pub unsafe fn from_raw_parts(ptr: *mut T, len: usize) -> Self {
+        Self { ptr, len }
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline(always)]
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
+
+    #[inline(always)]
+    pub fn as_mut_ptr(&self) -> *mut T {
+        self.ptr
+    }
+}
+
+impl<T> RawSliceMut<RawSlice<T>> {
+    /// Converts a slice of slices of [`T`] into [`RawSliceMut<RawSlice<T>>`]
+    /// # Safety
+    /// `slices` becomes invaild after use
+    /// as it is going to be reused as a memory location for creating `Self`
+    /// making this unexpensive but dangerous
+    /// O(N) expect if the Layout of RawSlice is equal to the Layout of rust slices, and it has been optimized it is O(1)
+    #[inline(always)]
+    pub unsafe fn from_slices(slices: *mut [&[T]]) -> Self {
+        let old_slices = unsafe { &mut *slices };
+        let raw_slices = unsafe { &mut *(slices as *mut [RawSlice<T>]) };
+
+        for (i, slice) in old_slices.iter().enumerate() {
+            raw_slices[i] = unsafe { RawSlice::from_slice(slice) };
+        }
+        unsafe { RawSliceMut::from_raw_parts(raw_slices.as_mut_ptr(), raw_slices.len()) }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct RawSliceMut<T> {
+    ptr: *mut T,
+    len: usize,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct NonNullSlice<T> {
+    ptr: NonNull<T>,
+    len: usize,
+}
+
+impl<T> NonNullSlice<T> {
+    pub const unsafe fn from_raw_parts(ptr: NonNull<T>, len: usize) -> Self {
+        Self { ptr, len }
+    }
+}
+
+/// A C complitable Option-like type
+#[derive(Debug)]
+#[repr(C)]
+pub enum Optional<T> {
+    None,
+    Some(T),
+}
+
+impl<T> From<Option<T>> for Optional<T> {
+    #[inline(always)]
+    fn from(value: Option<T>) -> Self {
+        match value {
+            None => Self::None,
+            Some(x) => Self::Some(x),
+        }
+    }
+}
+
+impl<T> From<Optional<T>> for Option<T> {
+    #[inline(always)]
+    fn from(value: Optional<T>) -> Self {
+        match value {
+            Optional::None => None,
+            Optional::Some(x) => Some(x),
+        }
+    }
+}
+
+impl<T: Clone> Clone for Optional<T> {
+    #[inline(always)]
+    fn clone(&self) -> Self {
+        match self {
+            Self::None => Self::None,
+            Self::Some(x) => Self::Some(x.clone()),
+        }
+    }
+}
+impl<T: Copy> Copy for Optional<T> {}
+
+impl<T: PartialEq> PartialEq for Optional<T> {
+    #[inline(always)]
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::None, Self::None) => true,
+            (Self::Some(x), Self::Some(y)) => x == y,
+            _ => false,
+        }
+    }
+}
+
+impl<T: Eq> Eq for Optional<T> {}

--- a/abi/src/raw/processes.rs
+++ b/abi/src/raw/processes.rs
@@ -22,10 +22,12 @@ impl TaskMetadata {
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
+/// Flags for the [crate::syscalls::SyscallTable::SysPSpawn] syscall
 pub struct SpawnFlags(u8);
 impl SpawnFlags {
     pub const CLONE_RESOURCES: Self = Self(1 << 0);
     pub const CLONE_CWD: Self = Self(1 << 1);
+    pub const EMPTY: Self = Self(0);
 }
 
 impl BitOr for SpawnFlags {

--- a/abi/src/raw/processes.rs
+++ b/abi/src/raw/processes.rs
@@ -47,22 +47,26 @@ pub struct SpawnConfig {
     pub argv: RawSliceMut<RawSlice<u8>>,
     pub flags: SpawnFlags,
     pub metadata: *const TaskMetadata,
+    pub env: RawSliceMut<RawSlice<u8>>,
 }
 
 impl SpawnConfig {
     pub fn new(
         name: &str,
         argv: *mut [&[u8]],
+        env: *mut [&[u8]],
         flags: SpawnFlags,
         metadata: Option<&TaskMetadata>,
     ) -> Self {
         let name = unsafe { RawSlice::from_slice(name.as_bytes()) };
         let argv = unsafe { RawSliceMut::from_slices(argv) };
+        let env = unsafe { RawSliceMut::from_slices(env) };
 
         Self {
             version: 1,
             name,
             argv,
+            env,
             flags,
             metadata: metadata
                 .map(|x| x as *const TaskMetadata)

--- a/abi/src/raw/processes.rs
+++ b/abi/src/raw/processes.rs
@@ -1,0 +1,9 @@
+use super::Optional;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct TaskMetadata {
+    pub stdout: Optional<usize>,
+    pub stdin: Optional<usize>,
+    pub stderr: Optional<usize>,
+}

--- a/abi/src/raw/processes.rs
+++ b/abi/src/raw/processes.rs
@@ -1,4 +1,6 @@
-use super::Optional;
+use core::ops::BitOr;
+
+use super::{Optional, RawSlice, RawSliceMut};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
@@ -6,4 +8,63 @@ pub struct TaskMetadata {
     pub stdout: Optional<usize>,
     pub stdin: Optional<usize>,
     pub stderr: Optional<usize>,
+}
+
+impl TaskMetadata {
+    pub fn new(stdout: Option<usize>, stdin: Option<usize>, stderr: Option<usize>) -> Self {
+        Self {
+            stdout: stdout.into(),
+            stdin: stdin.into(),
+            stderr: stderr.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct SpawnFlags(u8);
+impl SpawnFlags {
+    pub const CLONE_RESOURCES: Self = Self(1 << 0);
+    pub const CLONE_CWD: Self = Self(1 << 1);
+}
+
+impl BitOr for SpawnFlags {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+/// configuration for the spawn syscall
+#[repr(C)]
+pub struct SpawnConfig {
+    /// config version for compatibility
+    /// added in kernel version 0.2.1 and therfore breaking compatibility with any program compiled for version below 0.2.1
+    pub version: u8,
+    pub name: RawSlice<u8>,
+    pub argv: RawSliceMut<RawSlice<u8>>,
+    pub flags: SpawnFlags,
+    pub metadata: *const TaskMetadata,
+}
+
+impl SpawnConfig {
+    pub fn new(
+        name: &str,
+        argv: *mut [&[u8]],
+        flags: SpawnFlags,
+        metadata: Option<&TaskMetadata>,
+    ) -> Self {
+        let name = unsafe { RawSlice::from_slice(name.as_bytes()) };
+        let argv = unsafe { RawSliceMut::from_slices(argv) };
+
+        Self {
+            version: 1,
+            name,
+            argv,
+            flags,
+            metadata: metadata
+                .map(|x| x as *const TaskMetadata)
+                .unwrap_or(core::ptr::null()),
+        }
+    }
 }

--- a/abi/src/syscalls.rs
+++ b/abi/src/syscalls.rs
@@ -1,4 +1,5 @@
 /// defines Syscall numbers
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
 pub enum SyscallTable {

--- a/abi/src/syscalls.rs
+++ b/abi/src/syscalls.rs
@@ -27,6 +27,7 @@ pub enum SyscallTable {
 
     SysPSpawn = 19,
     SysWait = 11,
+    SysMetaTake = 25,
 
     SysShutdown = 20,
     SysReboot = 21,

--- a/abi/src/syscalls.rs
+++ b/abi/src/syscalls.rs
@@ -35,7 +35,7 @@ pub enum SyscallTable {
 
 impl SyscallTable {
     // update when a new Syscall Num is added
-    const MAX: u16 = Self::SysReboot as u16;
+    const MAX: u16 = Self::SysMetaTake as u16;
 }
 
 impl TryFrom<u16> for SyscallTable {

--- a/abi/src/syscalls.rs
+++ b/abi/src/syscalls.rs
@@ -34,6 +34,8 @@ pub enum SyscallTable {
 
     SysShutdown = 20,
     SysReboot = 21,
+    /// returns the Uptime of the system in milliseconds
+    SysUptime = 27,
 }
 
 impl SyscallTable {

--- a/abi/src/syscalls.rs
+++ b/abi/src/syscalls.rs
@@ -16,6 +16,8 @@ pub enum SyscallTable {
     SysSync = 16,
     SysTruncate = 17,
     SysCtl = 12,
+
+    SysDup = 26,
     // TODO: remove in favor of FAttrs
     SysFSize = 22,
     SysFAttrs = 24,
@@ -35,7 +37,7 @@ pub enum SyscallTable {
 
 impl SyscallTable {
     // update when a new Syscall Num is added
-    const MAX: u16 = Self::SysMetaTake as u16;
+    const MAX: u16 = Self::SysDup as u16;
 }
 
 impl TryFrom<u16> for SyscallTable {

--- a/abi/src/syscalls.rs
+++ b/abi/src/syscalls.rs
@@ -1,3 +1,4 @@
+/// defines Syscall numbers
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
 pub enum SyscallTable {

--- a/build.sh
+++ b/build.sh
@@ -112,7 +112,7 @@ cp -v limine/BOOTX64.EFI limine/BOOTIA32.EFI $ISO_BUILD_DIR/EFI/BOOT
 
 build_ramdisk
 
-echo "Putting the iso toghether from the iso root directory: $ISO_BUILD_DIR"
+echo "Putting the iso together from the iso root directory: $ISO_BUILD_DIR"
 xorriso -as mkisofs -b boot/limine/limine-bios-cd.bin \
             -no-emul-boot -boot-load-size 4 -boot-info-table \
             --efi-boot boot/limine/limine-uefi-cd.bin \

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ function build_ramdisk {
     RAMDISK_INCLUDE=(*)
     cd ..
 
-    
+
     # Add all the files in the ramdisk-include directory to the ramdisk root
     for i in "${RAMDISK_INCLUDE[@]}"
     do
@@ -29,7 +29,7 @@ function build_ramdisk {
     RAMDISK=("${RAMDISK[@]}" "${RAMDISK_BUILTIN[@]}")
 
     set -- "${RAMDISK[@]}"
-    
+
     # temporary ramdisk root
     mkdir -pv $ISO_BUILD_DIR/boot/ramdisk
 
@@ -78,10 +78,10 @@ function cargo_build_safaos {
     CWD=$(pwd)
     AT=$1
     ARGS="${@:2}"
-    
+
     cd "$AT"
 
-    cargo "$RUSTC_TOOLCHAIN" build $ARGS --target x86_64-unknown-safaos --message-format=json-render-diagnostics | jq -rs '.[] | select(.reason == "compiler-artifact") | select(.executable != null) | .executable'
+    cargo $RUSTC_TOOLCHAIN build $ARGS --target x86_64-unknown-safaos --message-format=json-render-diagnostics | jq -rs '.[] | select(.reason == "compiler-artifact") | select(.executable != null) | .executable'
 }
 
 function build_programs {

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,7 @@ function build_ramdisk {
     # Add all the files in the ramdisk-include directory to the ramdisk root
     for i in "${RAMDISK_INCLUDE[@]}"
     do
+	echo "$i: ramdisk-include/$i"
         RAMDISK+=("ramdisk-include/$i" "$i")
     done
 
@@ -35,8 +36,9 @@ function build_ramdisk {
 
     while [ ! -z  "$1" ] ; do
         O_PATH="$ISO_BUILD_DIR/boot/ramdisk/$2"
-        mkdir -pv $(dirname $O_PATH)
-        cp -rv "$1" "$O_PATH"
+        DIR=$(dirname $O_PATH)
+        mkdir -pv $DIR
+        cp -Trv "$1" $O_PATH
         shift 2
     done
 

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "kernel"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "compile-time",
@@ -246,7 +246,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "safa-abi"
-version = "0.1.2"
+version = "0.2.0"
 
 [[package]]
 name = "safa-utils"

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -247,7 +247,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.5"
+version = "0.2.6"
 
 [[package]]
 name = "safa-utils"

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -112,7 +112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "kernel"
+name = "kernel-snowball"
 version = "0.2.1"
 dependencies = [
  "bitflags",

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -246,7 +246,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "safa-utils"

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -247,7 +247,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.4"
+version = "0.2.5"
 
 [[package]]
 name = "safa-utils"

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -247,7 +247,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.3"
+version = "0.2.4"
 
 [[package]]
 name = "safa-utils"

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "serde_json",
  "slab",
  "spin",
+ "thiserror",
 ]
 
 [[package]]
@@ -343,6 +344,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -246,7 +246,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.2"
+version = "0.2.3"
 
 [[package]]
 name = "safa-utils"

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -246,7 +246,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "safa-abi"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "safa-utils"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { version = "1.0", git = "https://github.com/ObserverUnit/srede-jso
 
 compile-time = "0.2"
 slab = { version = "0.4", default-features = false }
+thiserror = { version = "2.0.12", default-features = false }
 [dev-dependencies]
 [features]
 test = []

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 name = "kernel"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 [package]
-name = "kernel"
+name = "kernel-snowball"
 version = "0.2.1"
 edition = "2021"
 

--- a/kernel/src/arch/x86_64/threading/mod.rs
+++ b/kernel/src/arch/x86_64/threading/mod.rs
@@ -20,7 +20,6 @@ use crate::{
         copy_to_userspace, frame_allocator,
         paging::{EntryFlags, MapToError, Page, PhysPageTable, PAGE_SIZE},
     },
-    serial,
     threading::swtch,
     VirtAddr,
 };
@@ -276,8 +275,6 @@ impl CPUStatus {
 
         let abi_structures_ptr = ABI_STRUCTURES_START as *const AbiStructures;
 
-        serial!("abi is {:#?}\n", structures);
-        serial!("abi ptr is {:#x}\n", abi_structures_ptr as usize);
         let (cs, ss, rflags) = if userspace {
             (
                 USER_CODE_SEG as u64,

--- a/kernel/src/devices/serial.rs
+++ b/kernel/src/devices/serial.rs
@@ -3,7 +3,7 @@ use core::fmt::Write;
 use crate::{
     arch::serial::Serial,
     drivers::vfs::{FSError, FSResult},
-    threading::expose::thread_yeild,
+    threading::expose::thread_yield,
     utils::Locked,
 };
 
@@ -26,7 +26,7 @@ impl CharDevice for Locked<Serial> {
                     writer.write_str(str).unwrap();
                     return Ok(buffer.len());
                 }
-                None => thread_yeild(),
+                None => thread_yield(),
             }
         }
     }

--- a/kernel/src/devices/tty.rs
+++ b/kernel/src/devices/tty.rs
@@ -6,7 +6,7 @@ use spin::RwLock;
 use crate::{
     drivers::vfs::{CtlArgs, FSError, FSResult},
     terminal::{TTYInterface, TTYSettings, TTY},
-    threading::expose::thread_yeild,
+    threading::expose::thread_yield,
     utils::bstr::BStr,
 };
 
@@ -46,7 +46,7 @@ impl<T: TTYInterface> CharDevice for RwLock<TTY<T>> {
                 tty.enable_input();
             }
 
-            thread_yeild();
+            thread_yield();
         }
     }
 
@@ -60,13 +60,13 @@ impl<T: TTYInterface> CharDevice for RwLock<TTY<T>> {
                     tty.write_bstr(str);
                     return Ok(buffer.len());
                 }
-                None => thread_yeild(),
+                None => thread_yield(),
             }
         }
     }
 
     fn ctl(&self, cmd: u16, mut args: CtlArgs) -> FSResult<()> {
-        let cmd = TTYCtlCmd::try_from(cmd).map_err(|_| FSError::InvaildCtlCmd)?;
+        let cmd = TTYCtlCmd::try_from(cmd).map_err(|_| FSError::InvalidCtlCmd)?;
         match cmd {
             TTYCtlCmd::GetFlags => {
                 let flags = args.get_ref_to::<TTYSettings>()?;
@@ -75,7 +75,7 @@ impl<T: TTYInterface> CharDevice for RwLock<TTY<T>> {
             }
             TTYCtlCmd::SetFlags => {
                 let flags: TTYSettings =
-                    TTYSettings::from_bits(args.get_ty()?).ok_or(FSError::InvaildCtlArg)?;
+                    TTYSettings::from_bits(args.get_ty()?).ok_or(FSError::InvalidCtlArg)?;
                 self.write().settings = flags;
                 Ok(())
             }
@@ -88,7 +88,7 @@ impl<T: TTYInterface> CharDevice for RwLock<TTY<T>> {
                     writer.sync();
                     return Ok(());
                 }
-                None => thread_yeild(),
+                None => thread_yield(),
             }
         }
     }

--- a/kernel/src/drivers/vfs/expose.rs
+++ b/kernel/src/drivers/vfs/expose.rs
@@ -19,6 +19,10 @@ use super::{
 pub struct File(usize);
 
 impl File {
+    pub const fn fd(&self) -> usize {
+        self.0
+    }
+
     fn with_fd<T, R>(&self, then: T) -> R
     where
         T: FnOnce(&mut FileDescriptor) -> R,

--- a/kernel/src/drivers/vfs/expose.rs
+++ b/kernel/src/drivers/vfs/expose.rs
@@ -96,6 +96,10 @@ impl File {
     pub fn attrs(&self) -> FileAttr {
         self.with_fd(|fd| fd.attrs())
     }
+
+    pub fn dup(&self) -> Self {
+        Self(resources::duplicate_resource(self.0))
+    }
 }
 
 impl Drop for File {
@@ -119,6 +123,11 @@ impl Readable for File {
 pub struct FileRef(ManuallyDrop<File>);
 
 impl FileRef {
+    pub fn dup(&self) -> Self {
+        let file = self.0.dup();
+        Self(ManuallyDrop::new(file))
+    }
+
     pub fn open(path: Path) -> FSResult<Self> {
         let file = File::open(path)?;
         Ok(Self(ManuallyDrop::new(file)))

--- a/kernel/src/drivers/vfs/expose.rs
+++ b/kernel/src/drivers/vfs/expose.rs
@@ -112,7 +112,7 @@ impl Drop for File {
 impl Readable for File {
     fn read(&self, offset: isize, buf: &mut [u8]) -> Result<usize, IoError> {
         self.read(offset, buf).map_err(|e| match e {
-            FSError::InvaildOffset => IoError::InvaildOffset,
+            FSError::InvalidOffset => IoError::InvalidOffset,
             _ => IoError::Generic,
         })
     }

--- a/kernel/src/drivers/vfs/mod.rs
+++ b/kernel/src/drivers/vfs/mod.rs
@@ -125,11 +125,13 @@ pub enum FSError {
     InvaildCtlCmd,
     InvaildCtlArg,
     NotEnoughArguments,
+    Other,
 }
 
 impl IntoErr for FSError {
     fn into_err(self) -> ErrorStatus {
         match self {
+            Self::Other => ErrorStatus::Generic,
             Self::OperationNotSupported => ErrorStatus::OperationNotSupported,
             Self::NotAFile => ErrorStatus::NotAFile,
             Self::NotADirectory => ErrorStatus::NotADirectory,
@@ -198,7 +200,7 @@ impl<'a> CtlArgs<'a> {
 }
 
 // InodeType implementition
-pub use safa_utils::abi::io::InodeType;
+pub use safa_utils::abi::raw::io::InodeType;
 
 pub trait InodeOps: Send + Sync {
     /// gets an Inode from self

--- a/kernel/src/drivers/vfs/mod.rs
+++ b/kernel/src/drivers/vfs/mod.rs
@@ -110,21 +110,21 @@ impl Drop for FileDescriptor {
 #[derive(Debug, Clone, Error)]
 #[repr(u8)]
 pub enum FSError {
-    InvaildResource,
+    InvalidResource,
     OperationNotSupported,
     NotAFile,
     NotADirectory,
     NoSuchAFileOrDirectory,
-    InvaildDrive,
-    InvaildPath,
+    InvalidDrive,
+    InvalidPath,
     PathTooLong,
     AlreadyExists,
-    NotExecuteable,
-    InvaildOffset,
-    InvaildName,
+    NotExecutable,
+    InvalidOffset,
+    InvalidName,
     /// Ctl
-    InvaildCtlCmd,
-    InvaildCtlArg,
+    InvalidCtlCmd,
+    InvalidCtlArg,
     NotEnoughArguments,
 }
 
@@ -141,15 +141,15 @@ impl IntoErr for FSError {
             Self::NotAFile => ErrorStatus::NotAFile,
             Self::NotADirectory => ErrorStatus::NotADirectory,
             Self::NoSuchAFileOrDirectory => ErrorStatus::NoSuchAFileOrDirectory,
-            Self::InvaildPath => ErrorStatus::InvaildPath,
-            Self::InvaildDrive => ErrorStatus::NoSuchAFileOrDirectory,
+            Self::InvalidPath => ErrorStatus::InvalidPath,
+            Self::InvalidDrive => ErrorStatus::NoSuchAFileOrDirectory,
             Self::AlreadyExists => ErrorStatus::AlreadyExists,
-            Self::NotExecuteable => ErrorStatus::NotExecutable,
-            Self::InvaildOffset => ErrorStatus::InvaildOffset,
-            Self::InvaildCtlCmd | Self::InvaildCtlArg => ErrorStatus::Generic,
-            Self::InvaildName | Self::PathTooLong => ErrorStatus::StrTooLong,
+            Self::NotExecutable => ErrorStatus::NotExecutable,
+            Self::InvalidOffset => ErrorStatus::InvalidOffset,
+            Self::InvalidCtlCmd | Self::InvalidCtlArg => ErrorStatus::Generic,
+            Self::InvalidName | Self::PathTooLong => ErrorStatus::StrTooLong,
             Self::NotEnoughArguments => ErrorStatus::NotEnoughArguments,
-            Self::InvaildResource => ErrorStatus::InvaildResource,
+            Self::InvalidResource => ErrorStatus::InvalidResource,
         }
     }
 }
@@ -157,9 +157,9 @@ impl IntoErr for FSError {
 impl From<PathError> for FSError {
     fn from(value: PathError) -> Self {
         match value {
-            PathError::DriveNameTooLong => Self::InvaildDrive,
+            PathError::DriveNameTooLong => Self::InvalidDrive,
             PathError::PathPartsTooLong => Self::PathTooLong,
-            PathError::FailedToJoinPaths | PathError::InvaildPath => Self::InvaildPath,
+            PathError::FailedToJoinPaths | PathError::InvalidPath => Self::InvalidPath,
         }
     }
 }
@@ -190,7 +190,7 @@ impl<'a> CtlArgs<'a> {
         let it = self.get_ty::<usize>()? as *mut T;
 
         if it.is_null() || !it.is_aligned() {
-            return Err(FSError::InvaildCtlArg);
+            return Err(FSError::InvalidCtlArg);
         }
         Ok(unsafe { &mut *it })
     }
@@ -201,7 +201,7 @@ impl<'a> CtlArgs<'a> {
             .get(self.index)
             .ok_or(FSError::NotEnoughArguments)?;
         self.index += 1;
-        T::try_from(*it).ok_or(FSError::InvaildCtlArg)
+        T::try_from(*it).ok_or(FSError::InvalidCtlArg)
     }
 }
 
@@ -346,7 +346,7 @@ pub trait FileSystem: Send + Sync {
     }
 
     /// goes trough path to get the inode it refers to
-    /// will err if there is no such a file or directory or path is straight up invaild
+    /// will err if there is no such a file or directory or path is straight up invalid
     fn resolve_pathparts(&self, path: PathParts, root_node: Inode) -> FSResult<Inode> {
         let mut current_inode = root_node;
         if path.is_empty() {
@@ -487,7 +487,7 @@ impl VFS {
     #[inline]
     fn get_from_path(&self, path: Path) -> FSResult<&Arc<dyn FileSystem>> {
         let drive = path.drive().expect("path is not absolute");
-        let drive = self.drives.get(drive).ok_or(FSError::InvaildDrive)?;
+        let drive = self.drives.get(drive).ok_or(FSError::InvalidDrive)?;
         Ok(drive)
     }
 
@@ -518,7 +518,7 @@ impl VFS {
         Ok((drive, resolved))
     }
 
-    /// resloves path into a Drive and an Inode
+    /// resolves path into a Drive and an Inode
     /// path may be relative to cwd or absolute
     #[must_use]
     #[inline]
@@ -541,16 +541,16 @@ impl VFS {
     ) -> FSResult<(&'a Arc<dyn FileSystem>, Inode, &'b str)> {
         let (name, path) = path.spilt_into_name();
 
-        let name = name.ok_or(FSError::InvaildPath)?;
-        let (drive, resloved) = self.resolve_path(path)?;
-        if resloved.kind() != InodeType::Directory {
+        let name = name.ok_or(FSError::InvalidPath)?;
+        let (drive, resolved) = self.resolve_path(path)?;
+        if resolved.kind() != InodeType::Directory {
             return Err(FSError::NotADirectory);
         }
 
-        Ok((drive, resloved, name))
+        Ok((drive, resolved, name))
     }
 
-    /// checks if a path is a vaild dir returns Err if path has an error
+    /// checks if a path is a valid dir returns Err if path has an error
     pub fn verify_path_dir(&self, path: Path) -> FSResult<()> {
         let (_, res) = self.resolve_path(path)?;
 

--- a/kernel/src/drivers/vfs/mod.rs
+++ b/kernel/src/drivers/vfs/mod.rs
@@ -369,7 +369,7 @@ pub trait FileSystem: Send + Sync {
         Ok(current_inode)
     }
 
-    /// creates an empty file named `name` relative to Inode   
+    /// creates an empty file named `name` relative to Inode
     fn create(&self, node: Inode, name: &str) -> FSResult<()> {
         _ = node;
         _ = name;
@@ -426,7 +426,9 @@ impl VFS {
 
         let moment_memory_usage = frame_allocator::mapped_frames();
         let the_now = time!();
-
+        // temporary directory
+        let tempfs = RwLock::new(ramfs::RamFS::new());
+        this.mount(DriveName::new_const("tmp"), tempfs).unwrap();
         // ramfs
         let ramfs = RwLock::new(ramfs::RamFS::new());
         this.mount(DriveName::new_const("ram"), ramfs).unwrap();

--- a/kernel/src/drivers/vfs/procfs/mod.rs
+++ b/kernel/src/drivers/vfs/procfs/mod.rs
@@ -141,7 +141,7 @@ impl super::InodeOps for Mutex<ProcInode> {
             ProcInodeData::File(file) => {
                 let file_data = file.get_data();
                 if offset >= file_data.len() as isize {
-                    return Err(FSError::InvaildOffset);
+                    return Err(FSError::InvalidOffset);
                 }
 
                 if offset >= 0 {
@@ -153,7 +153,7 @@ impl super::InodeOps for Mutex<ProcInode> {
                 } else {
                     let rev_offset = (-offset) as usize;
                     if rev_offset > file_data.len() {
-                        return Err(FSError::InvaildOffset);
+                        return Err(FSError::InvalidOffset);
                     }
                     // TODO: this is slower then inlining the code ourselves
                     self.read((file_data.len() - rev_offset) as isize + 1, buffer)

--- a/kernel/src/drivers/vfs/ramfs.rs
+++ b/kernel/src/drivers/vfs/ramfs.rs
@@ -93,7 +93,7 @@ impl InodeOps for RamInode {
             RamInodeData::Data(ref data) => {
                 let data = data.lock();
                 if offset >= data.len() as isize {
-                    return Err(FSError::InvaildOffset);
+                    return Err(FSError::InvalidOffset);
                 }
 
                 if offset >= 0 {
@@ -106,7 +106,7 @@ impl InodeOps for RamInode {
                     let rev_offset = (-offset) as usize;
                     let len = data.len();
                     if rev_offset > len + 1 {
-                        return Err(FSError::InvaildOffset);
+                        return Err(FSError::InvalidOffset);
                     }
 
                     drop(data);
@@ -138,7 +138,7 @@ impl InodeOps for RamInode {
                     let len = data.len();
 
                     if rev_offset > len + 1 {
-                        return Err(FSError::InvaildOffset);
+                        return Err(FSError::InvalidOffset);
                     }
 
                     drop(data);
@@ -273,7 +273,7 @@ impl FileSystem for RwLock<RamFS> {
     }
 
     fn create(&self, parent: Inode, name: &str) -> FSResult<()> {
-        let name = Name::try_from(name).map_err(|()| FSError::InvaildName)?;
+        let name = Name::try_from(name).map_err(|()| FSError::InvalidName)?;
         let mut write = self.write();
         let new_node = write.make_file();
         parent.insert(name, new_node)?;
@@ -281,7 +281,7 @@ impl FileSystem for RwLock<RamFS> {
     }
 
     fn createdir(&self, parent: Inode, name: &str) -> FSResult<()> {
-        let name = Name::from_str(name).map_err(|()| FSError::InvaildName)?;
+        let name = Name::from_str(name).map_err(|()| FSError::InvalidName)?;
 
         let mut write = self.write();
         let new_node = write.make_directory();
@@ -297,7 +297,7 @@ impl FileSystem for RwLock<RamFS> {
     }
 
     fn mount_device(&self, parent: Inode, name: &str, device: &'static dyn Device) -> FSResult<()> {
-        let name = Name::from_str(name).map_err(|()| FSError::InvaildName)?;
+        let name = Name::from_str(name).map_err(|()| FSError::InvalidName)?;
 
         let mut write = self.write();
         let new_node = write.make_device(device);

--- a/kernel/src/eve.rs
+++ b/kernel/src/eve.rs
@@ -74,6 +74,7 @@ pub fn main() -> ! {
 
     loop {
         one_shot();
+        core::hint::spin_loop();
     }
 }
 

--- a/kernel/src/eve.rs
+++ b/kernel/src/eve.rs
@@ -2,7 +2,11 @@
 //! it is responsible for managing a few things related to it's children
 
 use crate::{
-    debug, drivers::vfs, memory::paging::PhysPageTable, serial, threading::expose::thread_yeild,
+    debug,
+    drivers::vfs,
+    memory::paging::PhysPageTable,
+    serial,
+    threading::{self, expose::thread_yeild, task::TaskMetadata},
 };
 use alloc::vec::Vec;
 use safa_utils::make_path;
@@ -42,11 +46,16 @@ pub fn main() -> ! {
     // TODO: make a macro or a const function to do this automatically
     let stdin = vfs::expose::File::open(make_path!("dev", "tty")).unwrap();
     let stdout = vfs::expose::File::open(make_path!("dev", "tty")).unwrap();
+    let stderr = vfs::expose::File::open(make_path!("dev", "tty")).unwrap();
     serial!(
-        "Hello, world!, running tests... stdin: {:?}, stdout: {:?}\n",
+        "Hello, world!, running tests... stdin: {:?}, stdout: {:?}, stderr: {:?}\n",
         stdin,
-        stdout
+        stdout,
+        stderr
     );
+
+    let metadata = TaskMetadata::new(stdout.fd(), stdin.fd(), stderr.fd());
+    unsafe { threading::current().set_metadata(metadata) };
 
     #[cfg(feature = "test")]
     {

--- a/kernel/src/eve.rs
+++ b/kernel/src/eve.rs
@@ -66,6 +66,7 @@ pub fn main() -> ! {
             Name::try_from("TestRunner").unwrap(),
             crate::test::main,
             &[],
+            &[],
             SpawnFlags::CLONE_RESOURCES,
         )
         .unwrap();

--- a/kernel/src/globals.rs
+++ b/kernel/src/globals.rs
@@ -15,5 +15,5 @@ lazy_static! {
     pub static ref RSDP_ADDR: usize = limine::rsdp_addr();
 }
 
-pub const KERNEL_CODE_NAME: &str = "Snowball";
-pub const KERNEL_CODE_VERSION: &str = "0.2.0";
+pub const KERNEL_CODE_NAME: &str = env!("CARGO_PKG_NAME");
+pub const KERNEL_CODE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -25,6 +25,7 @@ mod threading;
 mod utils;
 
 extern crate alloc;
+use alloc::string::String;
 use arch::x86_64::serial;
 
 use drivers::keyboard::keys::Key;
@@ -140,7 +141,11 @@ fn print_stack_trace() {
 
             let name = {
                 let sym = KERNEL_ELF.sym_from_value_range(return_address);
-                sym.map(|sym| KERNEL_ELF.string_table_index(sym.name_index).unwrap())
+                sym.map(|sym| {
+                    KERNEL_ELF
+                        .string_table_index(sym.name_index)
+                        .unwrap_or(String::from("??"))
+                })
             };
             let name = name.as_deref().unwrap_or("???");
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -92,12 +92,12 @@ macro_rules! cross_println {
     };
 }
 
-/// runtime debug info that is only avalible though test feature
+/// runtime debug info that is only available though test feature
 /// takes a $mod and an Arguments, mod must be a type
 #[macro_export]
 macro_rules! debug {
     ($mod: path, $($arg:tt)*) => {
-        // makes sure $mod is a vaild type
+        // makes sure $mod is a valid type
         let _ = core::marker::PhantomData::<$mod>;
         $crate::serial!("\x1B[38;2;0;155;200m[DEBUG]\x1B[38;2;255;155;0m {}: \x1B[0m{}\n", stringify!($mod), format_args!($($arg)*));
     };
@@ -160,7 +160,7 @@ fn print_stack_trace() {
 extern "C" fn kstart() -> ! {
     arch::init_phase1();
     memory::sorcery::init_page_table();
-    println!("Terminal initialized successfuly");
+    println!("Terminal initialized successfully");
 
     // initing the arch
     arch::init_phase2();

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -63,8 +63,7 @@ macro_rules! time {
 }
 
 use core::arch::asm;
-#[no_mangle]
-#[inline]
+#[unsafe(no_mangle)]
 pub fn khalt() -> ! {
     loop {
         #[cfg(target_arch = "x86_64")]

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -9,6 +9,7 @@ use core::{
     fmt::{Debug, LowerHex},
     ops::{Deref, DerefMut, Index, IndexMut},
 };
+use thiserror::Error;
 
 use crate::memory::frame_allocator::Frame;
 
@@ -199,8 +200,9 @@ pub unsafe fn current_root_table() -> FramePtr<PageTable> {
     ptr
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, Error)]
 pub enum MapToError {
+    #[error("frame allocator: out of memory")]
     FrameAllocationFailed,
 }
 

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -150,9 +150,7 @@ pub struct PageTable {
 
 impl PageTable {
     pub fn zeroize(&mut self) {
-        for entry in &mut self.entries {
-            entry.0 = 0;
-        }
+        self.entries.fill(const { unsafe { core::mem::zeroed() } });
     }
 
     /// copies the higher half entries of the current pml4 to this page table
@@ -163,8 +161,6 @@ impl PageTable {
         }
     }
     /// deallocates a page table including it's entries, doesn't deallocate the higher half!
-    /// unsafe because self becomes almost invaild after use, the entries are not invalidated
-    /// meaning you can still use virtual addresses from the page table but using them will cause UB
     pub unsafe fn free(&mut self, level: u8) {
         for entry in &mut self.entries[0..HIGHER_HALF_ENTRY] {
             if entry.0 != 0 {

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -162,7 +162,15 @@ impl PageTable {
     }
     /// deallocates a page table including it's entries, doesn't deallocate the higher half!
     pub unsafe fn free(&mut self, level: u8) {
-        for entry in &mut self.entries[0..HIGHER_HALF_ENTRY] {
+        // if the table is the pml4 we need not to free the higher half
+        // because it is shared with other tables
+        let last_entry = if level >= 4 {
+            HIGHER_HALF_ENTRY
+        } else {
+            ENTRY_COUNT
+        };
+
+        for entry in &mut self.entries[0..last_entry] {
             if entry.0 != 0 {
                 entry.free(level - 1);
             }

--- a/kernel/src/syscalls/mod.rs
+++ b/kernel/src/syscalls/mod.rs
@@ -3,7 +3,6 @@ use safa_utils::abi::{self, raw};
 use safa_utils::errors::SysResult;
 
 use crate::drivers::vfs::expose::FileAttr;
-use crate::threading;
 use crate::threading::task::TaskMetadata;
 use crate::utils::syscalls::{SyscallFFI, SyscallTable};
 use crate::{
@@ -17,6 +16,7 @@ use crate::{
     utils::{errors::ErrorStatus, path::Path},
     VirtAddr,
 };
+use crate::{threading, time};
 
 impl SyscallFFI for FileRef {
     type Args = usize;
@@ -243,6 +243,10 @@ pub fn syscall(number: u16, a: usize, b: usize, c: usize, d: usize, e: usize) ->
             // power
             SyscallTable::SysShutdown => Ok(power::shutdown()),
             SyscallTable::SysReboot => Ok(power::reboot()),
+            SyscallTable::SysUptime => Ok({
+                let dest_uptime = <&mut u64>::make(a as *mut u64)?;
+                *dest_uptime = time!();
+            }),
             #[allow(unreachable_patterns)]
             syscall => {
                 debug!(

--- a/kernel/src/syscalls/mod.rs
+++ b/kernel/src/syscalls/mod.rs
@@ -156,6 +156,13 @@ pub fn syscall(number: u16, a: usize, b: usize, c: usize, d: usize, e: usize) ->
                 }
                 Ok(())
             }
+            SyscallTable::SysDup => {
+                let fd = FileRef::make(a)?;
+                let dest_fd = <&mut FileRef>::make(b as *mut FileRef)?;
+                let fd = fd.dup();
+                *dest_fd = fd;
+                Ok(())
+            }
             // processes
             SyscallTable::SysPSpawn => {
                 #[inline(always)]

--- a/kernel/src/syscalls/processes.rs
+++ b/kernel/src/syscalls/processes.rs
@@ -1,4 +1,4 @@
-use crate::utils::types::Name;
+use crate::{threading::task::TaskMetadata, utils::types::Name};
 use core::fmt::Write;
 
 use crate::{
@@ -19,6 +19,7 @@ pub fn syspspawn(
     path: Path,
     argv: &[&str],
     flags: SpawnFlags,
+    metadata: Option<TaskMetadata>,
     dest_pid: Option<&mut usize>,
 ) -> Result<(), ErrorStatus> {
     let name = match name {
@@ -30,7 +31,7 @@ pub fn syspspawn(
         }
     };
 
-    let results = threading::expose::pspawn(name, path, argv, flags)?;
+    let results = threading::expose::pspawn(name, path, argv, flags, metadata)?;
     if let Some(dest_pid) = dest_pid {
         *dest_pid = results;
     }

--- a/kernel/src/syscalls/processes.rs
+++ b/kernel/src/syscalls/processes.rs
@@ -18,6 +18,7 @@ pub fn syspspawn(
     name: Option<&str>,
     path: Path,
     argv: &[&str],
+    env: &[&[u8]],
     flags: SpawnFlags,
     metadata: Option<TaskMetadata>,
     dest_pid: Option<&mut usize>,
@@ -31,7 +32,7 @@ pub fn syspspawn(
         }
     };
 
-    let results = threading::expose::pspawn(name, path, argv, flags, metadata)?;
+    let results = threading::expose::pspawn(name, path, argv, env, flags, metadata)?;
     if let Some(dest_pid) = dest_pid {
         *dest_pid = results;
     }

--- a/kernel/src/syscalls/processes.rs
+++ b/kernel/src/syscalls/processes.rs
@@ -1,4 +1,6 @@
-use crate::{threading::task::TaskMetadata, utils::types::Name};
+use safa_utils::abi::raw::processes::{AbiStructures, TaskStdio};
+
+use crate::utils::types::Name;
 use core::fmt::Write;
 
 use crate::{
@@ -20,7 +22,7 @@ pub fn syspspawn(
     argv: &[&str],
     env: &[&[u8]],
     flags: SpawnFlags,
-    metadata: Option<TaskMetadata>,
+    stdio: Option<TaskStdio>,
     dest_pid: Option<&mut usize>,
 ) -> Result<(), ErrorStatus> {
     let name = match name {
@@ -32,7 +34,16 @@ pub fn syspspawn(
         }
     };
 
-    let results = threading::expose::pspawn(name, path, argv, env, flags, metadata)?;
+    let results = threading::expose::pspawn(
+        name,
+        path,
+        argv,
+        env,
+        flags,
+        AbiStructures {
+            stdio: stdio.unwrap_or_default(),
+        },
+    )?;
     if let Some(dest_pid) = dest_pid {
         *dest_pid = results;
     }

--- a/kernel/src/syscalls/utils.rs
+++ b/kernel/src/syscalls/utils.rs
@@ -12,7 +12,7 @@ pub fn sysexit(code: usize) -> ! {
 }
 
 pub fn sysyield() {
-    threading::expose::thread_yeild()
+    threading::expose::thread_yield()
 }
 
 pub fn syschdir(path: Path) -> Result<(), ErrorStatus> {

--- a/kernel/src/terminal/mod.rs
+++ b/kernel/src/terminal/mod.rs
@@ -9,6 +9,7 @@ use crate::{
         keys::{Key, KeyCode, KeyFlags},
         HandleKey,
     },
+    eve::KERNEL_ABI_STRUCTURES,
     threading::expose::{pspawn, SpawnFlags},
     utils::{alloc::PageBString, bstr::BStr},
 };
@@ -18,7 +19,7 @@ pub mod framebuffer;
 
 /// defines the interface for a tty
 /// a tty is a user-visible device that can be written to, and that user-input can be read from
-/// it is recommened for the tty to support ansii escape sequences, some stuff will be managed by a
+/// it is recommended for the tty to support ansii escape sequences, some stuff will be managed by a
 /// higher-level tty implementation `TTY` only writing to the tty is required
 pub trait TTYInterface: Send + Sync {
     fn write_str(&mut self, s: &BStr);
@@ -46,11 +47,11 @@ pub trait TTYInterface: Send + Sync {
 bitflags! {
     #[derive(Debug, Clone, Copy)]
     pub struct TTYSettings: u8 {
-        /// wether or not we are currently reciving input
+        /// whether or not we are currently receiving input
         /// the cursor should work well if enabled correctly using `self.enable_input` and disabled
         /// using `self.disable_input`
         // TODO: maybe the cursor should be the job of the shell?
-        const RECIVE_INPUT = 1 << 0;
+        const RECEIVE_INPUT = 1 << 0;
         const DRAW_GRAPHICS = 1 << 1;
         const CANONICAL_MODE = 1 << 2;
         const ECHO_INPUT = 1 << 3;
@@ -212,9 +213,9 @@ impl Stdin {
 
 #[allow(clippy::upper_case_acronyms)]
 pub struct TTY<T: TTYInterface> {
-    /// stores the stdout buffer for write operations peformed on the tty device, allows to write to the tty at once instead of a peice by piece
+    /// stores the stdout buffer for write operations performed on the tty device, allows to write to the tty at once instead of a piece by piece
     stdout_buffer: PageBString,
-    /// stores the stdin buffer for read operations peformed on the tty device
+    /// stores the stdin buffer for read operations performed on the tty device
     stdin: Stdin,
     pub settings: TTYSettings,
     interface: T,
@@ -283,20 +284,20 @@ impl<T: TTYInterface> TTY<T> {
     }
 
     pub fn enable_input(&mut self) {
-        if !self.settings.contains(TTYSettings::RECIVE_INPUT) {
-            self.settings |= TTYSettings::RECIVE_INPUT;
+        if !self.settings.contains(TTYSettings::RECEIVE_INPUT) {
+            self.settings |= TTYSettings::RECEIVE_INPUT;
             self.show_cursor();
         }
     }
 
     pub fn disable_input(&mut self) {
-        if self.settings.contains(TTYSettings::RECIVE_INPUT) {
-            self.settings &= !TTYSettings::RECIVE_INPUT;
+        if self.settings.contains(TTYSettings::RECEIVE_INPUT) {
+            self.settings &= !TTYSettings::RECEIVE_INPUT;
             self.hide_cursor();
         }
     }
 
-    pub fn peform_backspace(&mut self) {
+    pub fn perform_backspace(&mut self) {
         if !self.stdin().is_empty() {
             // backspace
             self.stdin.pop_at_cursor(Some(&mut self.stdout_buffer));
@@ -337,7 +338,7 @@ impl<T: TTYInterface> TTY<T> {
 
     #[inline(always)]
     const fn is_interactive(&self) -> bool {
-        self.settings.contains(TTYSettings::RECIVE_INPUT)
+        self.settings.contains(TTYSettings::RECEIVE_INPUT)
             && self.settings.contains(TTYSettings::CANONICAL_MODE)
     }
 }
@@ -374,14 +375,14 @@ impl<T: TTYInterface> HandleKey for TTY<T> {
                     make_path!("sys", "bin/safa"),
                     &["-i"],
                     &[b"PATH=sys:/bin", b"SHELL=sys:/bin/safa"],
-                    SpawnFlags::CLONE_RESOURCES,
-                    None,
+                    SpawnFlags::empty(),
+                    *KERNEL_ABI_STRUCTURES,
                 )
                 .unwrap();
             }
             KeyCode::Backspace if self.is_interactive() => {
                 self.hide_cursor();
-                self.peform_backspace();
+                self.perform_backspace();
                 self.show_cursor();
             }
 
@@ -395,7 +396,7 @@ impl<T: TTYInterface> HandleKey for TTY<T> {
                     write_key!();
                 }
             }
-            _ if self.settings.contains(TTYSettings::RECIVE_INPUT) => {
+            _ if self.settings.contains(TTYSettings::RECEIVE_INPUT) => {
                 let mapped = key.map_key();
                 if mapped.is_empty() {
                     return;

--- a/kernel/src/terminal/mod.rs
+++ b/kernel/src/terminal/mod.rs
@@ -374,6 +374,7 @@ impl<T: TTYInterface> HandleKey for TTY<T> {
                     make_path!("sys", "bin/safa"),
                     &["-i"],
                     SpawnFlags::CLONE_RESOURCES,
+                    None,
                 )
                 .unwrap();
             }

--- a/kernel/src/terminal/mod.rs
+++ b/kernel/src/terminal/mod.rs
@@ -373,6 +373,7 @@ impl<T: TTYInterface> HandleKey for TTY<T> {
                     // Maybe we can make a const function or a macro for this
                     make_path!("sys", "bin/safa"),
                     &["-i"],
+                    &[b"PATH=sys:/bin", b"SHELL=sys:/bin/safa"],
                     SpawnFlags::CLONE_RESOURCES,
                     None,
                 )

--- a/kernel/src/test.rs
+++ b/kernel/src/test.rs
@@ -128,12 +128,16 @@ pub mod testing_module {
 
     fn userspace() {
         unsafe { core::arch::asm!("cli") }
+        use crate::drivers::vfs::expose::File;
+        use crate::threading::task::TaskMetadata;
+
+        let stdio = File::open(make_path!("dev", "/ss")).unwrap();
         let pid = pspawn(
             Name::try_from("Tester").unwrap(),
             make_path!("sys", "bin/safa-tests"),
             &[],
-            SpawnFlags::empty(),
-            None,
+            SpawnFlags::CLONE_RESOURCES,
+            Some(TaskMetadata::new(stdio.fd(), stdio.fd(), stdio.fd())),
         )
         .unwrap();
         let ret = wait(pid);

--- a/kernel/src/test.rs
+++ b/kernel/src/test.rs
@@ -116,6 +116,7 @@ pub mod testing_module {
             Name::try_from("TEST_CASE").unwrap(),
             make_path!("sys", "/bin/true"),
             &[],
+            &[],
             SpawnFlags::empty(),
             None,
         )
@@ -135,6 +136,7 @@ pub mod testing_module {
         let pid = pspawn(
             Name::try_from("Tester").unwrap(),
             make_path!("sys", "bin/safa-tests"),
+            &[],
             &[],
             SpawnFlags::empty(),
             Some(TaskMetadata::new(stdio.fd(), stdio.fd(), stdio.fd())),

--- a/kernel/src/test.rs
+++ b/kernel/src/test.rs
@@ -116,7 +116,8 @@ pub mod testing_module {
             Name::try_from("TEST_CASE").unwrap(),
             make_path!("sys", "/bin/true"),
             &[],
-            SpawnFlags::CLONE_RESOURCES,
+            SpawnFlags::empty(),
+            None,
         )
         .unwrap();
         let ret = wait(pid);
@@ -132,6 +133,7 @@ pub mod testing_module {
             make_path!("sys", "bin/safa-tests"),
             &[],
             SpawnFlags::empty(),
+            None,
         )
         .unwrap();
         let ret = wait(pid);

--- a/kernel/src/test.rs
+++ b/kernel/src/test.rs
@@ -136,7 +136,7 @@ pub mod testing_module {
             Name::try_from("Tester").unwrap(),
             make_path!("sys", "bin/safa-tests"),
             &[],
-            SpawnFlags::CLONE_RESOURCES,
+            SpawnFlags::empty(),
             Some(TaskMetadata::new(stdio.fd(), stdio.fd(), stdio.fd())),
         )
         .unwrap();

--- a/kernel/src/threading/expose.rs
+++ b/kernel/src/threading/expose.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 use super::{
-    task::{Task, TaskInfo, TaskMetadata, TaskState},
+    task::{Task, TaskInfo, TaskMetadata},
     this_state, this_state_mut, Pid,
 };
 
@@ -128,12 +128,8 @@ fn spawn_inner(
 
     let provide_resources = || {
         let mut state = task.state_mut().unwrap();
-        let TaskState::Alive {
-            resources: task_resources,
-            ..
-        } = &mut *state
-        else {
-            unreachable!()
+        let Some(task_resources) = state.resource_manager_mut() else {
+            unreachable!();
         };
 
         drop(this);

--- a/kernel/src/threading/expose.rs
+++ b/kernel/src/threading/expose.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloc::boxed::Box;
 use bitflags::bitflags;
-use safa_utils::make_path;
+use safa_utils::{abi::raw, make_path};
 
 use crate::{
     drivers::vfs::{expose::File, FSError, FSResult, InodeType, VFS_STRUCT},
@@ -82,10 +82,15 @@ pub fn getinfo(pid: Pid) -> Option<TaskInfo> {
 
 bitflags! {
     #[derive(Debug, Clone, Copy)]
-    #[repr(C)]
     pub struct SpawnFlags: u8 {
         const CLONE_RESOURCES = 1 << 0;
         const CLONE_CWD = 1 << 1;
+    }
+}
+
+impl From<raw::processes::SpawnFlags> for SpawnFlags {
+    fn from(value: raw::processes::SpawnFlags) -> Self {
+        unsafe { Self::from_bits_retain(core::mem::transmute(value)) }
     }
 }
 

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -12,7 +12,7 @@ use crate::utils::types::Name;
 use alloc::{boxed::Box, rc::Rc, vec::Vec};
 use slab::Slab;
 use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use task::{Task, TaskInfo, TaskState};
+use task::{Task, TaskInfo, TaskMetadata, TaskState};
 
 use crate::{
     arch::threading::{restore_cpu_status, CPUStatus},
@@ -54,6 +54,7 @@ impl Scheduler {
             page_table,
             context,
             0,
+            TaskMetadata::default(),
         );
         self::add(task);
 
@@ -170,7 +171,7 @@ lazy_static! {
     static ref SCHEDULER: RwLock<Scheduler> = RwLock::new(Scheduler::new());
 }
 
-fn current() -> Rc<Task> {
+pub fn current() -> Rc<Task> {
     SCHEDULER.read().current().clone()
 }
 

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -6,13 +6,13 @@ pub type Pid = usize;
 
 use core::arch::asm;
 use lazy_static::lazy_static;
-use safa_utils::make_path;
+use safa_utils::{abi::raw::processes::AbiStructures, make_path};
 
 use crate::utils::types::Name;
 use alloc::{boxed::Box, rc::Rc, vec::Vec};
 use slab::Slab;
 use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use task::{Task, TaskInfo, TaskMetadata, TaskState};
+use task::{Task, TaskInfo, TaskState};
 
 use crate::{
     arch::threading::{restore_cpu_status, CPUStatus},
@@ -43,8 +43,15 @@ impl Scheduler {
         debug!(Scheduler, "initing ...");
         asm!("cli");
         let mut page_table = PhysPageTable::from_current();
-        let context =
-            CPUStatus::create(&mut page_table, &[], &[], function as usize, false).unwrap();
+        let context = CPUStatus::create(
+            &mut page_table,
+            &[],
+            &[],
+            AbiStructures::default(),
+            function as usize,
+            false,
+        )
+        .unwrap();
         let cwd = Box::new(make_path!("ram", "").into_owned().unwrap());
 
         let task = Task::new(
@@ -55,7 +62,6 @@ impl Scheduler {
             page_table,
             context,
             0,
-            TaskMetadata::default(),
         );
         self::add(task);
 
@@ -141,7 +147,7 @@ impl Scheduler {
     }
 
     #[inline(always)]
-    /// wether or not has been properly initialized using `init`
+    /// whether or not has been properly initialized using `init`
     pub fn inited(&self) -> bool {
         self.tasks.len() > 0
     }
@@ -158,7 +164,7 @@ impl Scheduler {
 }
 
 #[inline(always)]
-/// peforms a context switch using the scheduler, switching to the next task context
+/// performs a context switch using the scheduler, switching to the next task context
 /// to be used
 pub fn swtch(context: CPUStatus) -> CPUStatus {
     if let Some(mut scheduler) = SCHEDULER.try_write().filter(|s| s.inited()) {
@@ -230,7 +236,7 @@ pub fn this_state() -> RwLockReadGuard<'static, TaskState> {
     loop {
         match this().state() {
             Some(s) => return s,
-            None => expose::thread_yeild(),
+            None => expose::thread_yield(),
         }
     }
 }
@@ -244,7 +250,7 @@ pub fn this_state_mut() -> RwLockWriteGuard<'static, TaskState> {
     loop {
         match this().state_mut() {
             Some(s) => return s,
-            None => expose::thread_yeild(),
+            None => expose::thread_yield(),
         }
     }
 }

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -43,7 +43,8 @@ impl Scheduler {
         debug!(Scheduler, "initing ...");
         asm!("cli");
         let mut page_table = PhysPageTable::from_current();
-        let context = CPUStatus::create(&mut page_table, &[], function as usize, false).unwrap();
+        let context =
+            CPUStatus::create(&mut page_table, &[], &[], function as usize, false).unwrap();
         let cwd = Box::new(make_path!("ram", "").into_owned().unwrap());
 
         let task = Task::new(

--- a/kernel/src/threading/resources.rs
+++ b/kernel/src/threading/resources.rs
@@ -5,7 +5,7 @@ use spin::{Mutex, MutexGuard};
 
 use crate::drivers::vfs::{DirIterDescriptor, FileDescriptor};
 
-use super::expose::thread_yeild;
+use super::expose::thread_yield;
 
 #[derive(Clone)]
 pub enum Resource {
@@ -80,7 +80,7 @@ impl ResourceManager {
                 break;
             }
 
-            thread_yeild();
+            thread_yield();
         }
 
         if ri < self.next_ri {
@@ -114,7 +114,7 @@ impl ResourceManager {
     }
 
     /// gets a reference to the resource with index `ri`
-    /// returns `None` if `ri` is invaild
+    /// returns `None` if `ri` is invalid
     fn get(&self, ri: usize) -> Option<MutexGuard<Resource>> {
         if ri >= self.resources.len() {
             return None;

--- a/kernel/src/threading/resources.rs
+++ b/kernel/src/threading/resources.rs
@@ -113,6 +113,13 @@ impl ResourceManager {
 
         Some(self.resources[ri].lock())
     }
+
+    fn get_mut(&mut self, ri: usize) -> Option<&mut Resource> {
+        if ri >= self.resources.len() {
+            return None;
+        }
+        Some(self.resources[ri].get_mut())
+    }
 }
 // TODO: fgure out a better way to do this, where it's easier to tell that we are holding a lock on
 // the current process state.
@@ -137,6 +144,15 @@ pub fn add_resource(resource: Resource) -> usize {
         .resource_manager_mut()
         .unwrap()
         .add_resource(resource)
+}
+
+pub fn duplicate_resource(ri: usize) -> usize {
+    let mut state = super::this_state_mut();
+    let manager = state.resource_manager_mut().unwrap();
+
+    let resource = manager.get_mut(ri).unwrap();
+    let clone = resource.clone();
+    manager.add_resource(clone)
 }
 
 /// removes a resource from the current process with `ri`

--- a/kernel/src/threading/resources.rs
+++ b/kernel/src/threading/resources.rs
@@ -104,6 +104,15 @@ impl ResourceManager {
             .map(|r| Mutex::new(r.get_mut().clone()))
             .collect()
     }
+
+    pub fn clone_resource(&mut self, ri: usize) -> Option<ResourceItem> {
+        if ri >= self.resources.len() {
+            return None;
+        }
+
+        Some(Mutex::new(self.resources[ri].get_mut().clone()))
+    }
+
     /// gets a reference to the resource with index `ri`
     /// returns `None` if `ri` is invaild
     fn get(&self, ri: usize) -> Option<MutexGuard<Resource>> {

--- a/kernel/src/threading/task.rs
+++ b/kernel/src/threading/task.rs
@@ -331,13 +331,14 @@ impl Task {
         cwd: Box<PathBuf>,
         elf: Elf<T>,
         args: &[&str],
+        env: &[&[u8]],
         metadata: TaskMetadata,
     ) -> Result<Self, ElfError> {
         let entry_point = elf.header().entry_point;
         let mut page_table = PhysPageTable::create()?;
         let data_break = elf.load_exec(&mut page_table)?;
 
-        let context = unsafe { CPUStatus::create(&mut page_table, args, entry_point, true)? };
+        let context = unsafe { CPUStatus::create(&mut page_table, args, env, entry_point, true)? };
         Ok(Self::new(
             name, pid, ppid, cwd, page_table, context, data_break, metadata,
         ))

--- a/kernel/src/threading/task.rs
+++ b/kernel/src/threading/task.rs
@@ -154,7 +154,7 @@ impl AliveTask {
             }
         }
 
-        if is_negative {
+        if is_negative && amount >= usable_bytes {
             self.data_break -= amount;
         } else {
             self.data_break += amount;

--- a/kernel/src/threading/task.rs
+++ b/kernel/src/threading/task.rs
@@ -140,7 +140,7 @@ impl AliveTask {
         let is_negative = amount.is_negative();
         let amount = amount.unsigned_abs();
 
-        if usable_bytes < amount && !is_negative {
+        if (usable_bytes < amount) || (is_negative) {
             let pages = crate::memory::align_up(amount - usable_bytes, PAGE_SIZE) / PAGE_SIZE;
 
             let func = if is_negative {

--- a/kernel/src/utils/elf.rs
+++ b/kernel/src/utils/elf.rs
@@ -1,8 +1,11 @@
+use core::fmt::Display;
+
 use alloc::vec;
 use alloc::{slice, string::String, vec::Vec};
 use bitflags::bitflags;
 use macros::display_consts;
 use spin::once::Once;
+use thiserror::Error;
 
 use crate::{
     memory::{
@@ -82,7 +85,7 @@ pub struct ElfHeader {
     pub sections_names_section_offset: u16,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Error)]
 pub enum ElfError {
     UnsupportedClass,
     UnsupportedEndianness,
@@ -91,6 +94,12 @@ pub enum ElfError {
     NotAnElf,
     NotAnExecutable,
     MapToError,
+}
+
+impl Display for ElfError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 impl IntoErr for ElfError {

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -277,10 +277,11 @@ static MEMORY_INFO_CAPTURE: MemoryInfoCapture = MemoryInfoCapture::new();
 fn main() {
     // makes sure panic uses the custom println
     std::panic::set_hook(Box::new(panic_hook));
-    // DON'T REMOVE! MAKES SURE SERIAL IS FD 0
     log!("Running {} tests", TEST_LIST.len());
+
     for test in TEST_LIST {
         test.execute();
     }
+
     log!("Done running all tests");
 }

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "safa-abi"
-version = "0.1.2"
+version = "0.2.0"
 
 [[package]]
 name = "safa-utils"

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "safa-abi"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "safa-utils"

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "safa-abi"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "safa-utils"

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "safa-abi"
-version = "0.2.2"
+version = "0.2.3"
 
 [[package]]
 name = "safa-utils"

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "safa-abi"
-version = "0.2.4"
+version = "0.2.5"
 
 [[package]]
 name = "safa-utils"

--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "safa-abi"
-version = "0.2.3"
+version = "0.2.4"
 
 [[package]]
 name = "safa-utils"

--- a/utils/src/io.rs
+++ b/utils/src/io.rs
@@ -2,8 +2,8 @@ use core::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IoError {
-    InvaildOffset,
-    InvaildSize,
+    InvalidOffset,
+    InvalidSize,
     Generic,
 }
 
@@ -12,7 +12,7 @@ pub trait Readable {
     fn read_exact(&self, offset: isize, buf: &mut [u8]) -> Result<(), IoError> {
         let amount = self.read(offset, buf)?;
         if amount != buf.len() {
-            return Err(IoError::InvaildSize);
+            return Err(IoError::InvalidSize);
         }
         Ok(())
     }
@@ -22,7 +22,7 @@ impl Readable for &[u8] {
     fn read(&self, offset: isize, buf: &mut [u8]) -> Result<usize, IoError> {
         let offset = offset as usize;
         if offset >= self.len() {
-            return Err(IoError::InvaildOffset);
+            return Err(IoError::InvalidOffset);
         }
 
         let amount = buf.len().min(self.len() - offset);

--- a/utils/src/path.rs
+++ b/utils/src/path.rs
@@ -41,7 +41,7 @@ macro_rules! make_path {
 }
 #[derive(Debug, Clone, Copy)]
 pub enum PathError {
-    InvaildPath,
+    InvalidPath,
     FailedToJoinPaths,
     PathPartsTooLong,
     DriveNameTooLong,
@@ -50,7 +50,7 @@ pub enum PathError {
 impl IntoErr for PathError {
     fn into_err(self) -> ErrorStatus {
         match self {
-            Self::InvaildPath | Self::FailedToJoinPaths => ErrorStatus::InvaildPath,
+            Self::InvalidPath | Self::FailedToJoinPaths => ErrorStatus::InvalidPath,
             Self::DriveNameTooLong => ErrorStatus::NoSuchAFileOrDirectory,
             Self::PathPartsTooLong => ErrorStatus::StrTooLong,
         }
@@ -95,12 +95,12 @@ impl<'a> PathParts<'a> {
             return Self::default();
         }
 
-        let trimed = inner.trim();
-        let trimed = trimed.trim_matches('/');
+        let trimmed = inner.trim();
+        let trimmed = trimmed.trim_matches('/');
 
-        assert!(!trimed.contains(':'));
+        assert!(!trimmed.contains(':'));
 
-        Self { inner: trimed }
+        Self { inner: trimmed }
     }
 
     #[inline(always)]
@@ -372,10 +372,10 @@ impl<'a> Path<'a> {
 
         let first_part = parts.next();
         let second_part = parts.next();
-        let thrid_part = parts.next();
+        let third_part = parts.next();
 
-        if thrid_part.is_some() {
-            return Err(PathError::InvaildPath);
+        if third_part.is_some() {
+            return Err(PathError::InvalidPath);
         }
         let (drive, path) = match (first_part, second_part) {
             // paths like `sys:whatever` are ugly `sys:/whatever` is the correct way
@@ -383,7 +383,7 @@ impl<'a> Path<'a> {
             // relative paths must not start with a `/` i forgot why
             (Some(path), None) if !path.starts_with('/') => (None, Some(path)),
             (None, Some(_)) | (None, None) => unreachable!(),
-            _ => return Err(PathError::InvaildPath),
+            _ => return Err(PathError::InvalidPath),
         };
 
         let parts = if let Some(path) = path {

--- a/utils/src/syscalls.rs
+++ b/utils/src/syscalls.rs
@@ -8,7 +8,7 @@ pub trait SyscallFFI: Sized {
 }
 
 /// converts `*const T` into `None` if the pointer is null if it is not aligned it will return an
-/// [`ErrorStatus::InvaildPtr`]
+/// [`ErrorStatus::InvalidPtr`]
 impl<T> SyscallFFI for Option<&T> {
     type Args = *const T;
 
@@ -16,7 +16,7 @@ impl<T> SyscallFFI for Option<&T> {
         if args.is_null() {
             Ok(None)
         } else if !args.is_aligned() {
-            return Err(ErrorStatus::InvaildPtr);
+            return Err(ErrorStatus::InvalidPtr);
         } else {
             Ok(unsafe { Some(&*args) })
         }
@@ -24,7 +24,7 @@ impl<T> SyscallFFI for Option<&T> {
 }
 
 /// converts `*mut T` into `None` if the pointer is null if it is not aligned it will return an
-/// [`ErrorStatus::InvaildPtr`]
+/// [`ErrorStatus::InvalidPtr`]
 impl<T> SyscallFFI for Option<&mut T> {
     type Args = *mut T;
 
@@ -32,7 +32,7 @@ impl<T> SyscallFFI for Option<&mut T> {
         if args.is_null() {
             Ok(None)
         } else if !args.is_aligned() {
-            return Err(ErrorStatus::InvaildPtr);
+            return Err(ErrorStatus::InvalidPtr);
         } else {
             Ok(unsafe { Some(&mut *args) })
         }
@@ -59,7 +59,7 @@ impl SyscallFFI for Option<&str> {
         let opt = <Option<&[u8]>>::make((ptr, len))?;
 
         if let Some(slice) = opt {
-            let str = core::str::from_utf8(slice).map_err(|_| ErrorStatus::InvaildStr)?;
+            let str = core::str::from_utf8(slice).map_err(|_| ErrorStatus::InvalidStr)?;
             Ok(Some(str))
         } else {
             Ok(None)
@@ -73,7 +73,7 @@ impl<T> SyscallFFI for &T {
 
     fn make(args: Self::Args) -> Result<Self, ErrorStatus> {
         if args.is_null() || !args.is_aligned() {
-            Err(ErrorStatus::InvaildPtr)
+            Err(ErrorStatus::InvalidPtr)
         } else {
             Ok(unsafe { &*args })
         }
@@ -86,7 +86,7 @@ impl<T> SyscallFFI for &mut T {
 
     fn make(args: Self::Args) -> Result<Self, ErrorStatus> {
         if args.is_null() || !args.is_aligned() {
-            Err(ErrorStatus::InvaildPtr)
+            Err(ErrorStatus::InvalidPtr)
         } else {
             Ok(unsafe { &mut *args })
         }
@@ -101,7 +101,7 @@ impl<T> SyscallFFI for &[T] {
         if ptr.is_null() {
             Ok(&[])
         } else if !ptr.is_aligned() {
-            return Err(ErrorStatus::InvaildPtr);
+            return Err(ErrorStatus::InvalidPtr);
         } else {
             Ok(unsafe { core::slice::from_raw_parts(ptr, len) })
         }
@@ -115,7 +115,7 @@ impl<T> SyscallFFI for &mut [T] {
         if ptr.is_null() {
             Ok(&mut [])
         } else if !ptr.is_aligned() {
-            return Err(ErrorStatus::InvaildPtr);
+            return Err(ErrorStatus::InvalidPtr);
         } else {
             Ok(unsafe { core::slice::from_raw_parts_mut(ptr, len) })
         }
@@ -126,7 +126,7 @@ impl SyscallFFI for &str {
     type Args = (*const u8, usize);
     fn make(args: Self::Args) -> Result<Self, ErrorStatus> {
         let slice: &[u8] = SyscallFFI::make(args)?;
-        core::str::from_utf8(slice).map_err(|_| ErrorStatus::InvaildPtr)
+        core::str::from_utf8(slice).map_err(|_| ErrorStatus::InvalidPtr)
     }
 }
 


### PR DESCRIPTION
## Change-log:
- Bump kernel version to `v0.2.1`
- Change kernel name to `kernel-snowball`
- Environment variables
- `SysDup` syscall
- Changed how stdio are handled from hard-coded Resources (FDs) to Resources passed to `_start` by the parent Task (process).
- Bug fixes with significant impact on performance.